### PR TITLE
Split crate to library and binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,14 +115,6 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "enum_primitive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,23 +153,24 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gif 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jpeg-decoder 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiff 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "inflate"
-version = "0.3.4"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -215,7 +208,7 @@ dependencies = [
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lcs-diff 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -240,11 +233,22 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "num-integer"
-version = "0.1.36"
+name = "num-derive"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -252,30 +256,22 @@ name = "num-iter"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.1.42"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -288,13 +284,29 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "deflate 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "inflate 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -362,6 +374,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "syn"
+version = "0.15.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,8 +402,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -424,14 +462,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum deflate 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4dddda59aaab719767ab11d3efd9a714e95b610c4445d4435765021e9d52dfb1"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
-"checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum gif 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e41945ba23db3bf51b24756d73d81acb4f28d85c3dccc32c6fae904438c25f"
-"checksum image 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "545f000e8aa4e569e93f49c446987133452e0091c2494ac3efd3606aa3d309f2"
-"checksum inflate 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5f9f47468e9a76a6452271efadc88fe865a82be91fe75e6c0c57b87ccea59d4"
+"checksum gif 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4bca55ac1f213920ce3527ccd62386f1f15fa3f1714aeee1cf93f2c416903f"
+"checksum image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44665b4395d1844c96e7dc8ed5754782a1cdfd9ef458a80bbe45702681450504"
+"checksum inflate 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "84c683bde2d8413b8f1be3e459c30e4817672b6e7a31d9212b0323154e76eba7"
 "checksum jpeg-decoder 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0dfe27a6c0dabd772d0f9b9f8701c4ca12c4d1eebcadf2be1f6f70396f6a1434"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
@@ -440,13 +477,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
-"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+"checksum num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8af1847c907c2f04d7bfd572fb25bbb4385c637fe5be163cf2f8c5d778fe1e7d"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
-"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
+"checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
-"checksum png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
+"checksum png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f54b9600d584d3b8a739e1662a595fab051329eff43f20e7d8cc22872962145b"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "485541959c8ecc49865526fe6c4de9653dd6e60d829d6edf0be228167b60372d"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
@@ -456,9 +495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum tiff 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a2cc6c4fd13cb1cfd20abdb196e794ceccb29371855b7e7f575945f920a5b3c2"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,23 @@ keywords = [
     "lcs",
 ]
 
+[lib]
+name = "lcs_image_diff"
+path = "src/lib.rs"
+
 [[bin]]
 name = "lcs-image-diff"
 path = "src/main.rs"
+required-features = ["binary"]
+
+[features]
+default = ["binary"]
+binary = ["futures", "futures-cpupool"]
 
 [dependencies]
 base64 = "0.9.0"
 clap = "2.30.0"
-futures = "0.1.18"
-futures-cpupool = "0.1.8"
+futures = { version = "0.1.18", optional = true }
+futures-cpupool = { version = "0.1.8", optional = true }
 image = "0.18.0"
 lcs-diff = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,26 @@ required-features = ["binary"]
 
 [features]
 default = ["binary"]
-binary = ["futures", "futures-cpupool"]
+binary = ["futures", "futures-cpupool", "all_image_formats"]
+all_image_formats = [
+    "image/gif_codec",
+    "image/jpeg",
+    "image/ico",
+    "image/png_codec",
+    "image/pnm",
+    "image/tga",
+    "image/tiff",
+    "image/webp",
+    "image/bmp",
+    "image/hdr",
+    "image/dxt",
+    "image/jpeg_rayon"
+]
 
 [dependencies]
 base64 = "0.9.0"
 clap = "2.30.0"
 futures = { version = "0.1.18", optional = true }
 futures-cpupool = { version = "0.1.8", optional = true }
-image = "0.18.0"
+image = { version = "0.20", default-features = false }
 lcs-diff = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lcs-image-diff
-Image diff tool with LCS algorithm. rust port of [murooka/go-diff-image](https://github.com/murooka/go-diff-image)
+Image diff library and tool with LCS algorithm. rust port of [murooka/go-diff-image](https://github.com/murooka/go-diff-image)
 
 [![](http://meritbadge.herokuapp.com/lcs-image-diff)](https://crates.io/crates/lcs-image-diff)
 [![CircleCI](https://circleci.com/gh/bokuweb/lcs-image-diff-rs/tree/master.svg?style=svg)](https://circleci.com/gh/bokuweb/lcs-image-diff-rs/tree/master)
@@ -7,13 +7,39 @@ Image diff tool with LCS algorithm. rust port of [murooka/go-diff-image](https:/
 ## Requirements
 - latest Rust (recommend [rustup](https://www.rustup.rs/))
 
-## Installation
+## Library
+
+### Usage
+
+```toml
+# Cargo.toml
+[dependencies]
+image = "0.20"
+lcs-image-diff = { version = "0.1", default-features = false }
+```
+
+```rust
+use lcs_image_diff::compare;
+
+let mut before = image::open("before.png")?;
+let mut after = image::open("after.png")?;
+
+let diff = compare(&mut before, &mut after, 100.0 / 256.0)?;
+
+before.save("marked_before.png")?;
+after.save("marked_after.png")?;
+diff.save("diff.png")?;
+```
+
+## Binary
+
+### Installation
 
 ``` bash
 cargo install lcs-image-diff
 ```
 
-## Usage
+### Usage
 
 ```
 lcs-image-diff path/to/before.png path/to/after.png path/to/diff.png
@@ -25,7 +51,7 @@ lcs-image-diff path/to/before.png path/to/after.png path/to/diff.png
 | --------------- |---------------| -------------------- |
 | ![](https://github.com/bokuweb/lcs-image-diff-rs/blob/master/test/images/before.png?raw=true) | ![](https://github.com/bokuweb/lcs-image-diff-rs/blob/master/test/images/after.png?raw=true) |![](https://github.com/bokuweb/lcs-image-diff-rs/blob/master/test/images/diff.png?raw=true)|
 
-`lcs-image-diff` outputs marked before and after images too. 
+`lcs-image-diff` outputs marked before and after images too.
 
 | marked_before.png        | marked_after.png          |
 | --------------- |---------------|

--- a/src/image_creator.rs
+++ b/src/image_creator.rs
@@ -69,8 +69,8 @@ fn put_diff_pixels(
     data: &String,
     rgb: (u8, u8, u8),
     rate: f32,
-) {
-    let row = decode(data).unwrap();
+) -> Result<(), base64::DecodeError> {
+    let row = decode(data)?;
     for x in 0..img.dimensions().0 {
         let index = x as usize * 4;
         let pixel: Rgba<u8> = if row_width > x {
@@ -82,6 +82,7 @@ fn put_diff_pixels(
         };
         img.put_pixel(x as u32, y as u32, blend(pixel, rgb, rate));
     }
+    Ok(())
 }
 
 pub fn mark_org_image(
@@ -99,22 +100,22 @@ pub fn get_diff_image(
     after_width: u32,
     result: &Vec<DiffResult<String>>,
     rate: f32,
-) -> DynamicImage {
+) -> Result<DynamicImage, base64::DecodeError> {
     let height = result.len() as u32;
     let width = cmp::max(before_width, after_width);
     let mut img: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::new(width, height);
     for (y, d) in result.iter().enumerate() {
         match d {
             &DiffResult::Added(ref a) => {
-                put_diff_pixels(y, &mut img, after_width, &a.data, GREEN, rate)
+                put_diff_pixels(y, &mut img, after_width, &a.data, GREEN, rate)?
             }
             &DiffResult::Removed(ref r) => {
-                put_diff_pixels(y, &mut img, before_width, &r.data, RED, rate)
+                put_diff_pixels(y, &mut img, before_width, &r.data, RED, rate)?
             }
             &DiffResult::Common(ref c) => {
-                put_diff_pixels(y, &mut img, width, &c.data, BLACK, 0.0)
+                put_diff_pixels(y, &mut img, width, &c.data, BLACK, 0.0)?
             }
         }
     }
-    ImageRgba8(img)
+    Ok(ImageRgba8(img))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,29 @@ use image_creator::*;
 use image::*;
 pub use base64::DecodeError;
 
+/// Accepts two mutable references to `image::DynamicImage` and rate.
+/// Returns diff `image::DynamicImage` and marks removed and added
+/// parts on input images.
+///
+/// # Examples
+///
+/// ```no_run
+/// extern crate image;
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<Error>> {
+/// use lcs_image_diff::compare;
+///
+/// let mut before = image::open("before.png")?;
+/// let mut after = image::open("after.png")?;
+///
+/// let diff = compare(&mut before, &mut after, 100.0 / 256.0)?;
+///
+/// before.save("marked_before.png")?;
+/// after.save("marked_after.png")?;
+/// diff.save("diff.png")?;
+/// # Ok(())
+/// # }
+/// ```
 pub fn compare(
     before: &mut DynamicImage,
     after: &mut DynamicImage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,13 @@ mod image_creator;
 use diff::*;
 use image_creator::*;
 use image::*;
+pub use base64::DecodeError;
 
 pub fn compare(
     before: &mut DynamicImage,
     after: &mut DynamicImage,
     rate: f32
-) -> DynamicImage {
+) -> Result<DynamicImage, DecodeError> {
     let compare_before = CompareImage::new(before.dimensions(), before.raw_pixels());
     let compare_after = CompareImage::new(after.dimensions(), after.raw_pixels());
     let result = diff(compare_before, compare_after);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,35 @@
+extern crate base64;
+extern crate image;
+extern crate lcs_diff;
+
+mod diff;
+mod image_creator;
+
+use diff::*;
+use image_creator::*;
+use image::*;
+
+pub fn compare(
+    before: &mut DynamicImage,
+    after: &mut DynamicImage,
+    rate: f32
+) -> DynamicImage {
+    let compare_before = CompareImage::new(before.dimensions(), before.raw_pixels());
+    let compare_after = CompareImage::new(after.dimensions(), after.raw_pixels());
+    let result = diff(compare_before, compare_after);
+
+    let mut added: Vec<usize> = Vec::new();
+    let mut removed: Vec<usize> = Vec::new();
+    for d in result.iter() {
+        match d {
+            &lcs_diff::DiffResult::Added(ref a) => added.push(a.new_index.unwrap()),
+            &lcs_diff::DiffResult::Removed(ref r) => removed.push(r.old_index.unwrap()),
+            _ => (),
+        }
+    }
+
+    mark_org_image(before, RED, rate, &removed);
+    mark_org_image(after, GREEN, rate, &added);
+
+    get_diff_image(before.dimensions().0, after.dimensions().0, &result, rate)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,33 @@
-extern crate base64;
 extern crate futures;
 extern crate futures_cpupool;
 extern crate image;
-extern crate lcs_diff;
+extern crate lcs_image_diff;
 
 #[macro_use]
 extern crate clap;
 
-mod diff;
-mod image_creator;
 mod mkdir;
 mod rename;
 
+use std::fs::File;
+use std::path::Path;
 use image::*;
-use image_creator::*;
-use diff::*;
 use rename::*;
+use mkdir::*;
 use clap::{App, Arg};
 use futures_cpupool::CpuPool;
 use futures::{future, Future};
-use std::sync::{Arc, Mutex};
+use lcs_image_diff::compare;
 
 static RATE: f32 = 100.0 / 256.0;
+
+pub fn save_image(image: &DynamicImage, filename: &str) {
+    let path = Path::new(filename).parent().unwrap();
+    let _result = mkdirp(path);
+    let ref mut fout = File::create(filename).unwrap();
+    image.save(fout, PNG).unwrap();
+}
+
 fn main() {
     let app = App::new(crate_name!())
         .version(crate_version!())
@@ -45,62 +51,31 @@ fn main() {
     let matches = app.get_matches();
     let before_image = matches.value_of("before_image").unwrap();
     let after_image = matches.value_of("after_image").unwrap();
-    let diff_image = matches.value_of("diff_image").unwrap();
-    let before = image::open(before_image).unwrap();
-    let after = image::open(after_image).unwrap();
+    let diff_image = matches.value_of("diff_image").unwrap().to_owned();
+    let mut before = image::open(before_image).unwrap();
+    let mut after = image::open(after_image).unwrap();
 
-    let compare_before = CompareImage::new(before.dimensions(), before.raw_pixels());
-    let compare_after = CompareImage::new(after.dimensions(), after.raw_pixels());
-    let result = diff(compare_before, compare_after);
-
-    let mut added: Vec<usize> = Vec::new();
-    let mut removed: Vec<usize> = Vec::new();
-    for d in result.iter() {
-        match d {
-            &lcs_diff::DiffResult::Added(ref a) => added.push(a.new_index.unwrap()),
-            &lcs_diff::DiffResult::Removed(ref r) => removed.push(r.old_index.unwrap()),
-            _ => (),
-        }
-    }
     let marked_before = add_prefix_to_file_name(&before_image, &"marked_");
     let marked_after = add_prefix_to_file_name(&after_image, &"marked_");
 
-    let arc_before = Arc::new(Mutex::new(before)).clone();
-    let arc_after = Arc::new(Mutex::new(after)).clone();
-    let before_clone = arc_before.clone();
-    let after_clone = arc_after.clone();
+    let result = compare(&mut before, &mut after, RATE);
+
     {
         let thread_pool = CpuPool::new_num_cpus();
         let before_thread = thread_pool.spawn_fn(move || -> Result<(), ()> {
-            save_marked_org_image(
-                &marked_before,
-                &mut before_clone.lock().unwrap(),
-                (255, 119, 119),
-                RATE,
-                &removed,
-            );
+            save_image(&before, &marked_before);
             Ok(())
         });
         let after_thread = thread_pool.spawn_fn(move || -> Result<(), ()> {
-            save_marked_org_image(
-                &marked_after,
-                &mut after_clone.lock().unwrap(),
-                (99, 195, 99),
-                RATE,
-                &added,
-            );
+            save_image(&after, &marked_after);
             Ok(())
         });
-        future::join_all(vec![before_thread, after_thread])
+        let result_thread = thread_pool.spawn_fn(move || -> Result<(), ()> {
+            save_image(&result, &diff_image);
+            Ok(())
+        });
+        future::join_all(vec![before_thread, after_thread, result_thread])
             .wait()
             .unwrap();
     }
-
-    save_diff_image(
-        diff_image,
-        arc_before.lock().unwrap().dimensions().0,
-        arc_after.lock().unwrap().dimensions().0,
-        &result,
-        RATE,
-    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ extern crate clap;
 mod mkdir;
 mod rename;
 
-use std::fs::File;
 use std::path::Path;
 use image::*;
 use rename::*;
@@ -24,8 +23,7 @@ static RATE: f32 = 100.0 / 256.0;
 pub fn save_image(image: &DynamicImage, filename: &str) {
     let path = Path::new(filename).parent().unwrap();
     let _result = mkdirp(path);
-    let ref mut fout = File::create(filename).unwrap();
-    image.save(fout, PNG).unwrap();
+    image.save(filename).unwrap();
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
     let marked_before = add_prefix_to_file_name(&before_image, &"marked_");
     let marked_after = add_prefix_to_file_name(&after_image, &"marked_");
 
-    let result = compare(&mut before, &mut after, RATE);
+    let result = compare(&mut before, &mut after, RATE).unwrap();
 
     {
         let thread_pool = CpuPool::new_num_cpus();


### PR DESCRIPTION
This will allow to reuse the code in other applications/libraries.

I added some `features` in order to minimize the dependencies of the library itself and added them to `default` so `cargo install` still works as before.

Marking original images now runs in the same thread with diff but saving images to files are still in their own threads like in #2 and saving diff also has it's own thread now. Looks like it hasn't decreased performance:

**before**:
```
$ for i in {0..2}; do time ./target/release/lcs-image-diff before.png after.png diff.png; done

real	0m1,108s
user	0m1,266s
sys	0m0,099s

real	0m1,154s
user	0m1,157s
sys	0m0,117s

real	0m1,084s
user	0m1,258s
sys	0m0,104s
```
**after**:
```
$ for i in {0..2}; do time ./target/release/lcs-image-diff before.png after.png diff.png; done

real	0m1,058s
user	0m1,442s
sys	0m0,122s

real	0m0,972s
user	0m1,510s
sys	0m0,133s

real	0m0,962s
user	0m1,533s
sys	0m0,123s
```